### PR TITLE
잘못된 스키마 프로퍼티 네이밍에 대한 주석 + 변경불가 이유 설명

### DIFF
--- a/model/Building.js
+++ b/model/Building.js
@@ -47,6 +47,11 @@ const BuildingSchema = mongoose.Schema(
       type: String,
       required: true,
     },
+    /** connoisseur는 감정가(감정하는 사람)라는 뜻입니다. 감정 가격이라는 뜻인줄 알고 프로퍼티 이름을 초기에 잘못 지었습니다.
+     * 현재 크롤렁 대상 사이트의 robots.txt에 크롤링 허용 여부가 disallowed로 변경되고 사이트 HTML 구조가 바뀌어서 이름을 바꿀 수가 없는 상황입니다.
+     * (기존 데이터를 지우고 이름을 바꿔서 새로 크롤링 하는것이 불가능합니다.)
+     * 감정가(Appraised Price)라는 뜻으로 이해해주시면 감사하겠습니다.
+     */
     connoisseur: {
       type: String,
       required: true,

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,14 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-/* GET home page. */
 router.get('/', function (req, res, next) {
-  res.json({
-    ok: true,
-    status: 200,
-    message: 'this is a server',
-    cliEnvIsWorking: !!process.env.ENV,
-  });
+  res.send('hi');
 });
 
 module.exports = router;


### PR DESCRIPTION
## 개요

- 현재 네이밍이 잘못된 스키마 프로퍼티가 있으나, 이 이름을 변경하는 경우 DB의 모든 값을 변경해야 하는 문제가 있고, 크롤링 허용정책 문제때문에 처음부터 다시 크롤링 하는게 불가능한 상황입니다. 그래서 따로 주석으로 상황설명을 달아놨습니다.

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 다음과 같이 주석을 달았습니다.

```js
 /** connoisseur는 감정가(감정하는 사람)라는 뜻입니다. 감정 가격이라는 뜻인줄 알고 프로퍼티 이름을 초기에 잘못 지었습니다.
     * 현재 크롤렁 대상 사이트의 robots.txt에 크롤링 허용 여부가 disallowed로 변경되고 사이트 HTML 구조가 바뀌어서 이름을 바꿀 수가 없는 상황입니다.
     * (기존 데이터를 지우고 이름을 바꿔서 새로 크롤링 하는것이 불가능합니다.)
     * 감정가(Appraised Price)라는 뜻으로 이해해주시면 감사하겠습니다.
     */
```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [x] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항